### PR TITLE
add HNSW index search methods and signal

### DIFF
--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -7,7 +7,7 @@ from tests.test_utils import MOCKED_MODULES
 
 patch.dict("sys.modules", MOCKED_MODULES).start()
 
-from tx_extension_clip.index import CLIPIndex, CLIPFlatIndex
+from tx_extension_clip.index import CLIPIndex, CLIPFlatIndex, CLIPFloatIndex, CLIPHNSWIndex
 
 
 class TestCLIPIndices(unittest.TestCase):
@@ -93,6 +93,165 @@ class TestCLIPIndices(unittest.TestCase):
         self.assertEqual(results[1].metadata, 1)
         self.assertEqual(results[0].similarity_info.distance, 0)
         self.assertEqual(results[1].similarity_info.distance, 1)
+
+
+class TestCLIPFloatIndices(unittest.TestCase):
+    def setUp(self):
+        """Set up test vectors (normalized float32 vectors represented as hex strings)."""
+        # Create normalized random vectors for testing
+        np.random.seed(42)
+        vectors = []
+        for i in range(4):
+            vec = np.random.randn(512).astype(np.float32)
+            vec = vec / np.linalg.norm(vec)  # Normalize
+            vectors.append(vec)
+        
+        self.vector_hashes = [binascii.hexlify(v.tobytes()).decode() for v in vectors]
+        self.entries = [(h, i) for i, h in enumerate(self.vector_hashes)]
+
+    def test_clip_float_index_query(self):
+        """Test CLIPFloatIndex basic query functionality."""
+        index = CLIPFloatIndex(self.entries)
+        self.assertEqual(len(index), len(self.vector_hashes))
+
+        query_hash = self.vector_hashes[0]
+        results = index.query(query_hash)
+        
+        # Should find itself with distance ~0
+        self.assertGreater(len(results), 0)
+        self.assertEqual(results[0].metadata, 0)
+        self.assertLess(results[0].similarity_info.distance, 0.01)
+
+    def test_clip_float_index_query_top_k(self):
+        """Test CLIPFloatIndex top-k query."""
+        index = CLIPFloatIndex(self.entries)
+        query_hash = self.vector_hashes[0]
+        k = 2
+
+        results = index.query_top_k(query_hash, k)
+        
+        self.assertEqual(len(results), k)
+        # Results should be sorted by distance
+        for i in range(len(results) - 1):
+            self.assertLessEqual(
+                results[i].similarity_info.distance,
+                results[i + 1].similarity_info.distance
+            )
+
+    def test_clip_float_index_query_threshold(self):
+        """Test CLIPFloatIndex threshold-based query."""
+        index = CLIPFloatIndex(self.entries)
+        query_hash = self.vector_hashes[0]
+        threshold = 0.5
+
+        results = index.query_threshold(query_hash, threshold)
+        
+        # All results should be within threshold
+        for result in results:
+            self.assertLessEqual(result.similarity_info.distance, threshold)
+
+    def test_clip_hnsw_index_query(self):
+        """Test CLIPHNSWIndex basic query functionality."""
+        index = CLIPHNSWIndex(self.entries)
+        self.assertEqual(len(index), len(self.vector_hashes))
+
+        query_hash = self.vector_hashes[0]
+        results = index.query(query_hash)
+        
+        # Should find itself with distance ~0
+        self.assertGreater(len(results), 0)
+        self.assertEqual(results[0].metadata, 0)
+        self.assertLess(results[0].similarity_info.distance, 0.01)
+
+    def test_clip_hnsw_index_query_top_k(self):
+        """Test CLIPHNSWIndex top-k query."""
+        index = CLIPHNSWIndex(self.entries)
+        query_hash = self.vector_hashes[0]
+        k = 2
+
+        results = index.query_top_k(query_hash, k)
+        
+        self.assertEqual(len(results), k)
+        # Results should be sorted by distance (approximate)
+        for i in range(len(results) - 1):
+            self.assertLessEqual(
+                results[i].similarity_info.distance,
+                results[i + 1].similarity_info.distance + 0.01  # Allow small tolerance for HNSW approximation
+            )
+
+    def test_clip_hnsw_index_query_threshold(self):
+        """Test CLIPHNSWIndex threshold-based query."""
+        index = CLIPHNSWIndex(self.entries)
+        query_hash = self.vector_hashes[0]
+        threshold = 0.5
+
+        results = index.query_threshold(query_hash, threshold)
+        
+        # All results should be within threshold
+        for result in results:
+            self.assertLessEqual(result.similarity_info.distance, threshold)
+
+    def test_clip_hnsw_index_custom_parameters(self):
+        """Test CLIPHNSWIndex with custom HNSW parameters."""
+        # Create index with custom parameters
+        index = CLIPHNSWIndex(
+            self.entries,
+            M=16,
+            ef_construction=100,
+            ef_search=64
+        )
+        
+        self.assertEqual(len(index), len(self.vector_hashes))
+        
+        query_hash = self.vector_hashes[0]
+        results = index.query_top_k(query_hash, 2)
+        
+        # Should still work with custom parameters
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].metadata, 0)
+
+    def test_clip_hnsw_index_add_incremental(self):
+        """Test incremental addition to CLIPHNSWIndex."""
+        # Create empty index
+        index = CLIPHNSWIndex()
+        self.assertEqual(len(index), 0)
+        
+        # Add entries one by one
+        for hash, metadata in self.entries:
+            index.add(hash, metadata)
+        
+        self.assertEqual(len(index), len(self.vector_hashes))
+        
+        # Verify query still works
+        query_hash = self.vector_hashes[0]
+        results = index.query_top_k(query_hash, 1)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].metadata, 0)
+
+    def test_clip_hnsw_vs_float_consistency(self):
+        """Compare HNSW results with exact Float index for consistency."""
+        float_index = CLIPFloatIndex(self.entries)
+        hnsw_index = CLIPHNSWIndex(self.entries)
+        
+        query_hash = self.vector_hashes[0]
+        k = 3
+        
+        float_results = float_index.query_top_k(query_hash, k)
+        hnsw_results = hnsw_index.query_top_k(query_hash, k)
+        
+        # HNSW should find similar results (may not be identical due to approximation)
+        self.assertEqual(len(float_results), k)
+        self.assertEqual(len(hnsw_results), k)
+        
+        # The top result should be the same (the query itself)
+        self.assertEqual(float_results[0].metadata, hnsw_results[0].metadata)
+        
+        # Distances should be close
+        self.assertAlmostEqual(
+            float_results[0].similarity_info.distance,
+            hnsw_results[0].similarity_info.distance,
+            places=2
+        )
 
 
 if __name__ == "__main__":

--- a/tx_extension_clip/__init__.py
+++ b/tx_extension_clip/__init__.py
@@ -1,9 +1,10 @@
 from tx_extension_clip.manifest import CLIPExtensionManifest
-from tx_extension_clip.signal import CLIPFloatSignal, CLIPSignal
+from tx_extension_clip.signal import CLIPFloatSignal, CLIPSignal, CLIPHNSWSignal
 
 TX_MANIFEST = CLIPExtensionManifest(
     signal_types=(
         CLIPSignal,
         CLIPFloatSignal,
+        CLIPHNSWSignal,
     ),
 )

--- a/tx_extension_clip/config.py
+++ b/tx_extension_clip/config.py
@@ -13,6 +13,11 @@ CLIP_DISTANCE_THRESHOLD: int = (
 CLIP_FLOAT_SIMILARITY_THRESHOLD: float = 0.90
 CLIP_FLOAT_DISTANCE_THRESHOLD: float = 0.10
 
+# HNSW Index Configuration
+CLIP_HNSW_M: int = 32  # Number of connections per layer (trade-off between accuracy and memory)
+CLIP_HNSW_EF_CONSTRUCTION: int = 200  # Size of dynamic candidate list during construction (higher = better quality, slower build)
+CLIP_HNSW_EF_SEARCH: int = 128  # Size of dynamic candidate list during search (higher = better recall, slower search)
+
 CLIP_NORMALIZED: bool = True
 OPEN_CLIP_MODEL_NAME: str = "xlm-roberta-base-ViT-B-32"
 OPEN_CLIP_PRETRAINED: str = "laion5b_s13b_b90k"

--- a/tx_extension_clip/signal.py
+++ b/tx_extension_clip/signal.py
@@ -18,7 +18,7 @@ from tx_extension_clip.config import (
     CLIP_FLOAT_DISTANCE_THRESHOLD,
     CLIP_HASHER,
 )
-from tx_extension_clip.index import CLIPFloatIndex, CLIPIndex
+from tx_extension_clip.index import CLIPFloatIndex, CLIPIndex, CLIPHNSWIndex
 from tx_extension_clip.utils.distance import cosine_distance, hamming_distance
 
 class CLIPSignal(
@@ -141,3 +141,16 @@ class CLIPFloatSignal(
     @staticmethod
     def get_examples() -> t.List[str]:
         return []
+
+
+class CLIPHNSWSignal(CLIPFloatSignal):
+    """
+    CLIP signal using float32 vectors with HNSW approximate search.
+    Provides fast approximate nearest neighbor search for large-scale datasets.
+    """
+
+    INDICATOR_TYPE: str = "HASH_CLIP_HNSW"
+
+    @classmethod
+    def get_index_cls(cls) -> t.Type[CLIPHNSWIndex]:
+        return CLIPHNSWIndex


### PR DESCRIPTION
- Added HNSW-based CLIP float index (CLIPHNSWVectorIndex/CLIPHNSWIndex) with configurable M/ef settings for approximate search.
- Added CLIPHNSWSignal and registered it in the manifest; config now includes HNSW defaults.
- Expanded tests for float and HNSW indices (query/top-k/threshold, custom params, incremental adds, a check that the top HNSW result (the query itself) matches the exact float index).